### PR TITLE
Add composer on .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,17 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
+
+before_script:
+  - composer self-update
+  - composer install --prefer-source --no-interaction --dev
 
 branches:
   only:
     - master
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
Using composer autoload (#60) breaks travis (https://travis-ci.org/domnikl/DesignPatternsPHP/jobs/18189229).

This PR fix that, installing the dependencies before running tests.

Also added HHVM on travis testing, allowing failures.
