### PR TITLE
Fixed misspelling in Composite pattern README.md

### DIFF
--- a/Composite/README.md
+++ b/Composite/README.md
@@ -2,7 +2,7 @@
 
 # Purpose
 
-To treat a group of objects the same way as a single instance of the object.
+To treat a group of objects the same way as a single instance of the object. 
 
 # Examples
 


### PR DESCRIPTION
```
modified:   Composite/README.md
```
