### PR TITLE
style: Adopt PSR12

### DIFF
--- a/Behavioral/ChainOfResponsibilities/Handler.php
+++ b/Behavioral/ChainOfResponsibilities/Handler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\ChainOfResponsibilities;
 

--- a/Behavioral/ChainOfResponsibilities/Responsible/HttpInMemoryCacheHandler.php
+++ b/Behavioral/ChainOfResponsibilities/Responsible/HttpInMemoryCacheHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\ChainOfResponsibilities\Responsible;
 

--- a/Behavioral/ChainOfResponsibilities/Responsible/SlowDatabaseHandler.php
+++ b/Behavioral/ChainOfResponsibilities/Responsible/SlowDatabaseHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\ChainOfResponsibilities\Responsible;
 

--- a/Behavioral/ChainOfResponsibilities/Tests/ChainTest.php
+++ b/Behavioral/ChainOfResponsibilities/Tests/ChainTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\ChainOfResponsibilities\Tests;
 

--- a/Behavioral/Command/AddMessageDateCommand.php
+++ b/Behavioral/Command/AddMessageDateCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command;
 

--- a/Behavioral/Command/Command.php
+++ b/Behavioral/Command/Command.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command;
 

--- a/Behavioral/Command/HelloCommand.php
+++ b/Behavioral/Command/HelloCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command;
 

--- a/Behavioral/Command/Invoker.php
+++ b/Behavioral/Command/Invoker.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command;
 

--- a/Behavioral/Command/Receiver.php
+++ b/Behavioral/Command/Receiver.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command;
 
@@ -17,7 +19,7 @@ class Receiver
     public function write(string $str)
     {
         if ($this->enableDate) {
-            $str .= ' ['.date('Y-m-d').']';
+            $str .= ' [' . date('Y-m-d') . ']';
         }
 
         $this->output[] = $str;

--- a/Behavioral/Command/Tests/CommandTest.php
+++ b/Behavioral/Command/Tests/CommandTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command\Tests;
 

--- a/Behavioral/Command/Tests/UndoableCommandTest.php
+++ b/Behavioral/Command/Tests/UndoableCommandTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command\Tests;
 
@@ -23,11 +25,11 @@ class UndoableCommandTest extends TestCase
         $messageDateCommand->execute();
 
         $invoker->run();
-        $this->assertSame("Hello World\nHello World [".date('Y-m-d').']', $receiver->getOutput());
+        $this->assertSame("Hello World\nHello World [" . date('Y-m-d') . ']', $receiver->getOutput());
 
         $messageDateCommand->undo();
 
         $invoker->run();
-        $this->assertSame("Hello World\nHello World [".date('Y-m-d')."]\nHello World", $receiver->getOutput());
+        $this->assertSame("Hello World\nHello World [" . date('Y-m-d') . "]\nHello World", $receiver->getOutput());
     }
 }

--- a/Behavioral/Command/UndoableCommand.php
+++ b/Behavioral/Command/UndoableCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Command;
 

--- a/Behavioral/Interpreter/AbstractExp.php
+++ b/Behavioral/Interpreter/AbstractExp.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Interpreter;
 

--- a/Behavioral/Interpreter/AndExp.php
+++ b/Behavioral/Interpreter/AndExp.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Interpreter;
 

--- a/Behavioral/Interpreter/Context.php
+++ b/Behavioral/Interpreter/Context.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Interpreter;
 

--- a/Behavioral/Interpreter/OrExp.php
+++ b/Behavioral/Interpreter/OrExp.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Interpreter;
 

--- a/Behavioral/Interpreter/Tests/InterpreterTest.php
+++ b/Behavioral/Interpreter/Tests/InterpreterTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Interpreter\Tests;
 

--- a/Behavioral/Interpreter/VariableExp.php
+++ b/Behavioral/Interpreter/VariableExp.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Interpreter;
 

--- a/Behavioral/Iterator/Book.php
+++ b/Behavioral/Iterator/Book.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Iterator;
 
@@ -20,6 +22,6 @@ class Book
 
     public function getAuthorAndTitle(): string
     {
-        return $this->getTitle().' by '.$this->getAuthor();
+        return $this->getTitle() . ' by ' . $this->getAuthor();
     }
 }

--- a/Behavioral/Iterator/BookList.php
+++ b/Behavioral/Iterator/BookList.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Iterator;
 

--- a/Behavioral/Iterator/Tests/IteratorTest.php
+++ b/Behavioral/Iterator/Tests/IteratorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Iterator\Tests;
 

--- a/Behavioral/Mediator/Colleague.php
+++ b/Behavioral/Mediator/Colleague.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Mediator;
 

--- a/Behavioral/Mediator/Mediator.php
+++ b/Behavioral/Mediator/Mediator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Mediator;
 

--- a/Behavioral/Mediator/Tests/MediatorTest.php
+++ b/Behavioral/Mediator/Tests/MediatorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Tests\Mediator\Tests;
 

--- a/Behavioral/Mediator/Ui.php
+++ b/Behavioral/Mediator/Ui.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Mediator;
 

--- a/Behavioral/Mediator/UserRepository.php
+++ b/Behavioral/Mediator/UserRepository.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Mediator;
 

--- a/Behavioral/Mediator/UserRepositoryUiMediator.php
+++ b/Behavioral/Mediator/UserRepositoryUiMediator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Mediator;
 

--- a/Behavioral/Memento/Memento.php
+++ b/Behavioral/Memento/Memento.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Memento;
 

--- a/Behavioral/Memento/State.php
+++ b/Behavioral/Memento/State.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Memento;
 
@@ -6,10 +8,10 @@ use InvalidArgumentException;
 
 class State implements \Stringable
 {
-    const STATE_CREATED = 'created';
-    const STATE_OPENED = 'opened';
-    const STATE_ASSIGNED = 'assigned';
-    const STATE_CLOSED = 'closed';
+    public const STATE_CREATED = 'created';
+    public const STATE_OPENED = 'opened';
+    public const STATE_ASSIGNED = 'assigned';
+    public const STATE_CLOSED = 'closed';
 
     private string $state;
 

--- a/Behavioral/Memento/Tests/MementoTest.php
+++ b/Behavioral/Memento/Tests/MementoTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Memento\Tests;
 

--- a/Behavioral/Memento/Ticket.php
+++ b/Behavioral/Memento/Ticket.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Memento;
 

--- a/Behavioral/NullObject/Logger.php
+++ b/Behavioral/NullObject/Logger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\NullObject;
 

--- a/Behavioral/NullObject/NullLogger.php
+++ b/Behavioral/NullObject/NullLogger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\NullObject;
 

--- a/Behavioral/NullObject/PrintLogger.php
+++ b/Behavioral/NullObject/PrintLogger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\NullObject;
 

--- a/Behavioral/NullObject/Service.php
+++ b/Behavioral/NullObject/Service.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\NullObject;
 
@@ -14,6 +16,6 @@ class Service
     public function doSomething()
     {
         // notice here that you don't have to check if the logger is set with eg. is_null(), instead just use it
-        $this->logger->log('We are in '.__METHOD__);
+        $this->logger->log('We are in ' . __METHOD__);
     }
 }

--- a/Behavioral/NullObject/Tests/LoggerTest.php
+++ b/Behavioral/NullObject/Tests/LoggerTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\NullObject\Tests;
 

--- a/Behavioral/Observer/Tests/ObserverTest.php
+++ b/Behavioral/Observer/Tests/ObserverTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Observer\Tests;
 

--- a/Behavioral/Observer/User.php
+++ b/Behavioral/Observer/User.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Observer;
 

--- a/Behavioral/Observer/UserObserver.php
+++ b/Behavioral/Observer/UserObserver.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Observer;
 

--- a/Behavioral/Specification/AndSpecification.php
+++ b/Behavioral/Specification/AndSpecification.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification;
 

--- a/Behavioral/Specification/Item.php
+++ b/Behavioral/Specification/Item.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification;
 

--- a/Behavioral/Specification/NotSpecification.php
+++ b/Behavioral/Specification/NotSpecification.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification;
 

--- a/Behavioral/Specification/OrSpecification.php
+++ b/Behavioral/Specification/OrSpecification.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification;
 

--- a/Behavioral/Specification/PriceSpecification.php
+++ b/Behavioral/Specification/PriceSpecification.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification;
 

--- a/Behavioral/Specification/Specification.php
+++ b/Behavioral/Specification/Specification.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification;
 

--- a/Behavioral/Specification/Tests/SpecificationTest.php
+++ b/Behavioral/Specification/Tests/SpecificationTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Specification\Tests;
 

--- a/Behavioral/State/OrderContext.php
+++ b/Behavioral/State/OrderContext.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\State;
 

--- a/Behavioral/State/State.php
+++ b/Behavioral/State/State.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\State;
 

--- a/Behavioral/State/StateCreated.php
+++ b/Behavioral/State/StateCreated.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\State;
 

--- a/Behavioral/State/StateDone.php
+++ b/Behavioral/State/StateDone.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\State;
 

--- a/Behavioral/State/StateShipped.php
+++ b/Behavioral/State/StateShipped.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\State;
 

--- a/Behavioral/State/Tests/StateTest.php
+++ b/Behavioral/State/Tests/StateTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\State\Tests;
 

--- a/Behavioral/Strategy/Comparator.php
+++ b/Behavioral/Strategy/Comparator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Strategy;
 

--- a/Behavioral/Strategy/Context.php
+++ b/Behavioral/Strategy/Context.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Strategy;
 

--- a/Behavioral/Strategy/DateComparator.php
+++ b/Behavioral/Strategy/DateComparator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Strategy;
 

--- a/Behavioral/Strategy/IdComparator.php
+++ b/Behavioral/Strategy/IdComparator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Strategy;
 

--- a/Behavioral/Strategy/Tests/StrategyTest.php
+++ b/Behavioral/Strategy/Tests/StrategyTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Strategy\Tests;
 

--- a/Behavioral/TemplateMethod/BeachJourney.php
+++ b/Behavioral/TemplateMethod/BeachJourney.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\TemplateMethod;
 

--- a/Behavioral/TemplateMethod/CityJourney.php
+++ b/Behavioral/TemplateMethod/CityJourney.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\TemplateMethod;
 

--- a/Behavioral/TemplateMethod/Journey.php
+++ b/Behavioral/TemplateMethod/Journey.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\TemplateMethod;
 

--- a/Behavioral/TemplateMethod/Tests/JourneyTest.php
+++ b/Behavioral/TemplateMethod/Tests/JourneyTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\TemplateMethod\Tests;
 

--- a/Behavioral/Visitor/Group.php
+++ b/Behavioral/Visitor/Group.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Visitor;
 

--- a/Behavioral/Visitor/RecordingVisitor.php
+++ b/Behavioral/Visitor/RecordingVisitor.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Visitor;
 

--- a/Behavioral/Visitor/Role.php
+++ b/Behavioral/Visitor/Role.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Visitor;
 

--- a/Behavioral/Visitor/RoleVisitor.php
+++ b/Behavioral/Visitor/RoleVisitor.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Visitor;
 

--- a/Behavioral/Visitor/Tests/VisitorTest.php
+++ b/Behavioral/Visitor/Tests/VisitorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Tests\Visitor\Tests;
 

--- a/Behavioral/Visitor/User.php
+++ b/Behavioral/Visitor/User.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Behavioral\Visitor;
 

--- a/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
+++ b/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\AbstractFactory\Tests;
 

--- a/Creational/Builder/Builder.php
+++ b/Creational/Builder/Builder.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder;
 

--- a/Creational/Builder/CarBuilder.php
+++ b/Creational/Builder/CarBuilder.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder;
 

--- a/Creational/Builder/Director.php
+++ b/Creational/Builder/Director.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder;
 

--- a/Creational/Builder/Parts/Car.php
+++ b/Creational/Builder/Parts/Car.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Parts;
 

--- a/Creational/Builder/Parts/Door.php
+++ b/Creational/Builder/Parts/Door.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Parts;
 

--- a/Creational/Builder/Parts/Engine.php
+++ b/Creational/Builder/Parts/Engine.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Parts;
 

--- a/Creational/Builder/Parts/Truck.php
+++ b/Creational/Builder/Parts/Truck.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Parts;
 

--- a/Creational/Builder/Parts/Vehicle.php
+++ b/Creational/Builder/Parts/Vehicle.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Parts;
 

--- a/Creational/Builder/Parts/Wheel.php
+++ b/Creational/Builder/Parts/Wheel.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Parts;
 

--- a/Creational/Builder/Tests/DirectorTest.php
+++ b/Creational/Builder/Tests/DirectorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder\Tests;
 

--- a/Creational/Builder/TruckBuilder.php
+++ b/Creational/Builder/TruckBuilder.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Builder;
 

--- a/Creational/FactoryMethod/FileLogger.php
+++ b/Creational/FactoryMethod/FileLogger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod;
 

--- a/Creational/FactoryMethod/FileLoggerFactory.php
+++ b/Creational/FactoryMethod/FileLoggerFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod;
 

--- a/Creational/FactoryMethod/Logger.php
+++ b/Creational/FactoryMethod/Logger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod;
 

--- a/Creational/FactoryMethod/LoggerFactory.php
+++ b/Creational/FactoryMethod/LoggerFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod;
 

--- a/Creational/FactoryMethod/StdoutLogger.php
+++ b/Creational/FactoryMethod/StdoutLogger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod;
 

--- a/Creational/FactoryMethod/StdoutLoggerFactory.php
+++ b/Creational/FactoryMethod/StdoutLoggerFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod;
 

--- a/Creational/FactoryMethod/Tests/FactoryMethodTest.php
+++ b/Creational/FactoryMethod/Tests/FactoryMethodTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\FactoryMethod\Tests;
 

--- a/Creational/Pool/StringReverseWorker.php
+++ b/Creational/Pool/StringReverseWorker.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Pool;
 

--- a/Creational/Pool/Tests/PoolTest.php
+++ b/Creational/Pool/Tests/PoolTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Pool\Tests;
 

--- a/Creational/Pool/WorkerPool.php
+++ b/Creational/Pool/WorkerPool.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Pool;
 

--- a/Creational/Prototype/BarBookPrototype.php
+++ b/Creational/Prototype/BarBookPrototype.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Prototype;
 

--- a/Creational/Prototype/BookPrototype.php
+++ b/Creational/Prototype/BookPrototype.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Prototype;
 

--- a/Creational/Prototype/FooBookPrototype.php
+++ b/Creational/Prototype/FooBookPrototype.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Prototype;
 

--- a/Creational/Prototype/Tests/PrototypeTest.php
+++ b/Creational/Prototype/Tests/PrototypeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Prototype\Tests;
 

--- a/Creational/SimpleFactory/Bicycle.php
+++ b/Creational/SimpleFactory/Bicycle.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\SimpleFactory;
 

--- a/Creational/SimpleFactory/SimpleFactory.php
+++ b/Creational/SimpleFactory/SimpleFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\SimpleFactory;
 

--- a/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
+++ b/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\SimpleFactory\Tests;
 

--- a/Creational/Singleton/Singleton.php
+++ b/Creational/Singleton/Singleton.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Singleton;
 
@@ -34,7 +36,7 @@ final class Singleton
     private function __clone()
     {
     }
-    
+
     /**
      * prevent from being unserialized (which would create a second instance of it)
      */

--- a/Creational/Singleton/Tests/SingletonTest.php
+++ b/Creational/Singleton/Tests/SingletonTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\Singleton\Tests;
 

--- a/Creational/StaticFactory/FormatNumber.php
+++ b/Creational/StaticFactory/FormatNumber.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\StaticFactory;
 

--- a/Creational/StaticFactory/FormatString.php
+++ b/Creational/StaticFactory/FormatString.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\StaticFactory;
 

--- a/Creational/StaticFactory/Formatter.php
+++ b/Creational/StaticFactory/Formatter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\StaticFactory;
 

--- a/Creational/StaticFactory/StaticFactory.php
+++ b/Creational/StaticFactory/StaticFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\StaticFactory;
 

--- a/Creational/StaticFactory/Tests/StaticFactoryTest.php
+++ b/Creational/StaticFactory/Tests/StaticFactoryTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Creational\StaticFactory\Tests;
 

--- a/More/EAV/Attribute.php
+++ b/More/EAV/Attribute.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\EAV;
 

--- a/More/EAV/Entity.php
+++ b/More/EAV/Entity.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\EAV;
 

--- a/More/EAV/Tests/EAVTest.php
+++ b/More/EAV/Tests/EAVTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\EAV\Tests;
 

--- a/More/EAV/Value.php
+++ b/More/EAV/Value.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\EAV;
 

--- a/More/Repository/Domain/Post.php
+++ b/More/Repository/Domain/Post.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository\Domain;
 

--- a/More/Repository/Domain/PostId.php
+++ b/More/Repository/Domain/PostId.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository\Domain;
 

--- a/More/Repository/Domain/PostStatus.php
+++ b/More/Repository/Domain/PostStatus.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository\Domain;
 
@@ -10,11 +12,11 @@ use InvalidArgumentException;
  */
 class PostStatus
 {
-    const STATE_DRAFT_ID = 1;
-    const STATE_PUBLISHED_ID = 2;
+    public const STATE_DRAFT_ID = 1;
+    public const STATE_PUBLISHED_ID = 2;
 
-    const STATE_DRAFT = 'draft';
-    const STATE_PUBLISHED = 'published';
+    public const STATE_DRAFT = 'draft';
+    public const STATE_PUBLISHED = 'published';
 
     private static array $validStates = [
         self::STATE_DRAFT_ID => self::STATE_DRAFT,

--- a/More/Repository/InMemoryPersistence.php
+++ b/More/Repository/InMemoryPersistence.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository;
 

--- a/More/Repository/Persistence.php
+++ b/More/Repository/Persistence.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository;
 

--- a/More/Repository/PostRepository.php
+++ b/More/Repository/PostRepository.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository;
 

--- a/More/Repository/Tests/PostRepositoryTest.php
+++ b/More/Repository/Tests/PostRepositoryTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\Repository\Tests;
 

--- a/More/ServiceLocator/LogService.php
+++ b/More/ServiceLocator/LogService.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\ServiceLocator;
 

--- a/More/ServiceLocator/ServiceLocator.php
+++ b/More/ServiceLocator/ServiceLocator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\ServiceLocator;
 

--- a/More/ServiceLocator/Tests/ServiceLocatorTest.php
+++ b/More/ServiceLocator/Tests/ServiceLocatorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\More\ServiceLocator\Tests;
 

--- a/Structural/Adapter/Book.php
+++ b/Structural/Adapter/Book.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Adapter;
 

--- a/Structural/Adapter/EBook.php
+++ b/Structural/Adapter/EBook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Adapter;
 

--- a/Structural/Adapter/EBookAdapter.php
+++ b/Structural/Adapter/EBookAdapter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Adapter;
 

--- a/Structural/Adapter/Kindle.php
+++ b/Structural/Adapter/Kindle.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Adapter;
 

--- a/Structural/Adapter/PaperBook.php
+++ b/Structural/Adapter/PaperBook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Adapter;
 

--- a/Structural/Adapter/Tests/AdapterTest.php
+++ b/Structural/Adapter/Tests/AdapterTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Adapter\Tests;
 

--- a/Structural/Bridge/Formatter.php
+++ b/Structural/Bridge/Formatter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge;
 

--- a/Structural/Bridge/HelloWorldService.php
+++ b/Structural/Bridge/HelloWorldService.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge;
 

--- a/Structural/Bridge/HtmlFormatter.php
+++ b/Structural/Bridge/HtmlFormatter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge;
 

--- a/Structural/Bridge/PingService.php
+++ b/Structural/Bridge/PingService.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge;
 

--- a/Structural/Bridge/PlainTextFormatter.php
+++ b/Structural/Bridge/PlainTextFormatter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge;
 

--- a/Structural/Bridge/Service.php
+++ b/Structural/Bridge/Service.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge;
 

--- a/Structural/Bridge/Tests/BridgeTest.php
+++ b/Structural/Bridge/Tests/BridgeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Bridge\Tests;
 

--- a/Structural/Composite/Form.php
+++ b/Structural/Composite/Form.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Composite;
 

--- a/Structural/Composite/InputElement.php
+++ b/Structural/Composite/InputElement.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Composite;
 

--- a/Structural/Composite/Renderable.php
+++ b/Structural/Composite/Renderable.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Composite;
 

--- a/Structural/Composite/Tests/CompositeTest.php
+++ b/Structural/Composite/Tests/CompositeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Composite\Tests;
 

--- a/Structural/Composite/TextElement.php
+++ b/Structural/Composite/TextElement.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Composite;
 

--- a/Structural/DataMapper/StorageAdapter.php
+++ b/Structural/DataMapper/StorageAdapter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DataMapper;
 

--- a/Structural/DataMapper/Tests/DataMapperTest.php
+++ b/Structural/DataMapper/Tests/DataMapperTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DataMapper\Tests;
 

--- a/Structural/DataMapper/User.php
+++ b/Structural/DataMapper/User.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DataMapper;
 

--- a/Structural/DataMapper/UserMapper.php
+++ b/Structural/DataMapper/UserMapper.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DataMapper;
 

--- a/Structural/Decorator/Booking.php
+++ b/Structural/Decorator/Booking.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Decorator;
 

--- a/Structural/Decorator/BookingDecorator.php
+++ b/Structural/Decorator/BookingDecorator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Decorator;
 

--- a/Structural/Decorator/DoubleRoomBooking.php
+++ b/Structural/Decorator/DoubleRoomBooking.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Decorator;
 

--- a/Structural/Decorator/ExtraBed.php
+++ b/Structural/Decorator/ExtraBed.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Decorator;
 

--- a/Structural/Decorator/Tests/DecoratorTest.php
+++ b/Structural/Decorator/Tests/DecoratorTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Decorator\Tests;
 

--- a/Structural/Decorator/WiFi.php
+++ b/Structural/Decorator/WiFi.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Decorator;
 

--- a/Structural/DependencyInjection/DatabaseConfiguration.php
+++ b/Structural/DependencyInjection/DatabaseConfiguration.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DependencyInjection;
 

--- a/Structural/DependencyInjection/DatabaseConnection.php
+++ b/Structural/DependencyInjection/DatabaseConnection.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DependencyInjection;
 

--- a/Structural/DependencyInjection/Tests/DependencyInjectionTest.php
+++ b/Structural/DependencyInjection/Tests/DependencyInjectionTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\DependencyInjection\Tests;
 

--- a/Structural/Facade/Bios.php
+++ b/Structural/Facade/Bios.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Facade;
 

--- a/Structural/Facade/Facade.php
+++ b/Structural/Facade/Facade.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Facade;
 

--- a/Structural/Facade/OperatingSystem.php
+++ b/Structural/Facade/OperatingSystem.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Facade;
 

--- a/Structural/Facade/Tests/FacadeTest.php
+++ b/Structural/Facade/Tests/FacadeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Facade\Tests;
 

--- a/Structural/FluentInterface/Sql.php
+++ b/Structural/FluentInterface/Sql.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\FluentInterface;
 
@@ -17,7 +19,7 @@ class Sql implements \Stringable
 
     public function from(string $table, string $alias): Sql
     {
-        $this->from[] = $table.' AS '.$alias;
+        $this->from[] = $table . ' AS ' . $alias;
 
         return $this;
     }

--- a/Structural/FluentInterface/Tests/FluentInterfaceTest.php
+++ b/Structural/FluentInterface/Tests/FluentInterfaceTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\FluentInterface\Tests;
 

--- a/Structural/Flyweight/Character.php
+++ b/Structural/Flyweight/Character.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Flyweight;
 

--- a/Structural/Flyweight/Tests/FlyweightTest.php
+++ b/Structural/Flyweight/Tests/FlyweightTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Flyweight\Tests;
 

--- a/Structural/Flyweight/Text.php
+++ b/Structural/Flyweight/Text.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Flyweight;
 

--- a/Structural/Flyweight/TextFactory.php
+++ b/Structural/Flyweight/TextFactory.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Flyweight;
 

--- a/Structural/Proxy/BankAccount.php
+++ b/Structural/Proxy/BankAccount.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Proxy;
 

--- a/Structural/Proxy/BankAccountProxy.php
+++ b/Structural/Proxy/BankAccountProxy.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Proxy;
 

--- a/Structural/Proxy/HeavyBankAccount.php
+++ b/Structural/Proxy/HeavyBankAccount.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Proxy;
 

--- a/Structural/Proxy/Tests/ProxyTest.php
+++ b/Structural/Proxy/Tests/ProxyTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Proxy\Tests;
 

--- a/Structural/Registry/Registry.php
+++ b/Structural/Registry/Registry.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Registry;
 
@@ -6,7 +8,7 @@ use InvalidArgumentException;
 
 abstract class Registry
 {
-    const LOGGER = 'logger';
+    public const LOGGER = 'logger';
 
     /**
      * this introduces global state in your application which can not be mocked up for testing

--- a/Structural/Registry/Tests/RegistryTest.php
+++ b/Structural/Registry/Tests/RegistryTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DesignPatterns\Structural\Registry\Tests;
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": "^3",
-        "flyeralarm/php-code-validator": "^2.2",
         "vimeo/psalm": "^4",
         "psalm/plugin-phpunit": "*",
         "rector/rector": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40404fe777c8f5e94a46511a604ee3dc",
+    "content-hash": "c660894bd4b5a538c9d0e6a7a9151c24",
     "packages": [
         {
             "name": "psr/http-message",
@@ -806,48 +806,6 @@
                 "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
             },
             "time": "2021-02-22T14:02:09+00:00"
-        },
-        {
-            "name": "flyeralarm/php-code-validator",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/flyeralarm/php-code-validator.git",
-                "reference": "2db2ce13e36ee13567fdbf42cc464264166025b8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/flyeralarm/php-code-validator/zipball/2db2ce13e36ee13567fdbf42cc464264166025b8",
-                "reference": "2db2ce13e36ee13567fdbf42cc464264166025b8",
-                "shasum": ""
-            },
-            "require": {
-                "squizlabs/php_codesniffer": "^3.0"
-            },
-            "bin": [
-                "bin/php-code-validator"
-            ],
-            "type": "config",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Müller",
-                    "email": "daniel.mueller@flyeralarm.com"
-                },
-                {
-                    "name": "Maximilian Grosch",
-                    "email": "maximilian.grosch@flyeralarm.com"
-                }
-            ],
-            "description": "A custom coding standard for FLYERALARM",
-            "support": {
-                "issues": "https://github.com/flyeralarm/php-code-validator/issues",
-                "source": "https://github.com/flyeralarm/php-code-validator/tree/2.3.0"
-            },
-            "time": "2020-10-02T09:10:58+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -7015,5 +6973,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,5 +4,5 @@
     <exclude-pattern>vendor</exclude-pattern>
     <arg value="sp"/>
 
-    <rule ref="vendor/flyeralarm/php-code-validator/ruleset.xml"/>
+    <rule ref="PSR12"/>
 </ruleset>


### PR DESCRIPTION
Dev dependency flyeralarm/php-code-validator has been removed.

Most files were automatically changed with `phpcbf` to adopt the PSR-12 standard.

The following files were manually changed to stop with PHPCS warnings about `const` without `public/private` scope:

- `Behavioral/Memento/State.php`
- `More/Repository/Domain/PostStatus.php`
- `Structural/Registry/Registry.php`

Closes #444