### PR TITLE
Fix PHPUnit issue

### DIFF
--- a/Creational/Singleton/Singleton.php
+++ b/Creational/Singleton/Singleton.php
@@ -36,7 +36,7 @@ final class Singleton
     /**
      * prevent from being unserialized (which would create a second instance of it)
      */
-    private function __wakeup()
+    public function __wakeup()
     {
     }
 }


### PR DESCRIPTION
Running these composer commands below during the Docker execution or out of the Docker we have the error below.

```
composer install \
    && ./vendor/bin/phpcs --ignore=_build . \
    && ./vendor/bin/phpunit \
    && ./vendor/bin/psalm --show-info=false \
    && ./check-refs-readmes
```

**Before:**

<img width="1045" alt="Screen Shot 2021-10-14 at 11 45 26 PM" src="https://user-images.githubusercontent.com/610598/137429547-d8fa1f4f-94b6-4cc5-aec0-7d9bef54ee9c.png">

**After:**

<img width="798" alt="Screen Shot 2021-10-14 at 11 46 02 PM" src="https://user-images.githubusercontent.com/610598/137429556-034fce59-f310-440f-8855-8f1ecc7ee442.png">

