### PR TITLE
EAV: Update missing type declarations

### DIFF
--- a/More/EAV/Attribute.php
+++ b/More/EAV/Attribute.php
@@ -15,7 +15,7 @@ class Attribute implements \Stringable
         $this->values = new SplObjectStorage();
     }
 
-    public function addValue(Value $value)
+    public function addValue(Value $value): void
     {
         $this->values->attach($value);
     }

--- a/More/EAV/Entity.php
+++ b/More/EAV/Entity.php
@@ -16,7 +16,7 @@ class Entity implements \Stringable
     /**
      * @param Value[] $values
      */
-    public function __construct(private string $name, $values)
+    public function __construct(private string $name, array $values)
     {
         $this->values = new SplObjectStorage();
 

--- a/More/EAV/Tests/EAVTest.php
+++ b/More/EAV/Tests/EAVTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class EAVTest extends TestCase
 {
-    public function testCanAddAttributeToEntity()
+    public function testCanAddAttributeToEntity(): void
     {
         $colorAttribute = new Attribute('color');
         $colorSilver = new Value($colorAttribute, 'silver');


### PR DESCRIPTION
This PR adds a missing return type to `Attribute::addValue()`, a missing return type to `EAVTest::testCanAddAttributeToEntity()`, and a missing type declaration in `Entity::__construct()`.