### PR TITLE
Final public method for abstract class

### DIFF
--- a/Behavioral/Mediator/Colleague.php
+++ b/Behavioral/Mediator/Colleague.php
@@ -8,7 +8,7 @@ abstract class Colleague
 {
     protected Mediator $mediator;
 
-    public function setMediator(Mediator $mediator)
+    final public function setMediator(Mediator $mediator)
     {
         $this->mediator = $mediator;
     }

--- a/Behavioral/TemplateMethod/Journey.php
+++ b/Behavioral/TemplateMethod/Journey.php
@@ -58,7 +58,7 @@ abstract class Journey
     /**
      * @return string[]
      */
-    public function getThingsToDo(): array
+    final public function getThingsToDo(): array
     {
         return $this->thingsToDo;
     }

--- a/Creational/Builder/Parts/Vehicle.php
+++ b/Creational/Builder/Parts/Vehicle.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Creational\Builder\Parts;
 
 abstract class Vehicle
 {
-    public function setPart(string $key, object $value)
+    final public function setPart(string $key, object $value)
     {
     }
 }

--- a/Creational/Prototype/BookPrototype.php
+++ b/Creational/Prototype/BookPrototype.php
@@ -11,12 +11,12 @@ abstract class BookPrototype
 
     abstract public function __clone();
 
-    public function getTitle(): string
+    final public function getTitle(): string
     {
         return $this->title;
     }
 
-    public function setTitle(string $title): void
+    final public function setTitle(string $title): void
     {
         $this->title = $title;
     }

--- a/Structural/Bridge/Service.php
+++ b/Structural/Bridge/Service.php
@@ -10,7 +10,7 @@ abstract class Service
     {
     }
 
-    public function setImplementation(Formatter $printer)
+    final public function setImplementation(Formatter $printer)
     {
         $this->implementation = $printer;
     }

--- a/Structural/Registry/Registry.php
+++ b/Structural/Registry/Registry.php
@@ -22,7 +22,7 @@ abstract class Registry
         self::LOGGER,
     ];
 
-    public static function set(string $key, Service $value)
+    final public static function set(string $key, Service $value)
     {
         if (!in_array($key, self::$allowedKeys)) {
             throw new InvalidArgumentException('Invalid key given');
@@ -31,7 +31,7 @@ abstract class Registry
         self::$services[$key] = $value;
     }
 
-    public static function get(string $key): Service
+    final public static function get(string $key): Service
     {
         if (!in_array($key, self::$allowedKeys) || !isset(self::$services[$key])) {
             throw new InvalidArgumentException('Invalid key given');


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.