### PR TITLE
Void return

### DIFF
--- a/Behavioral/ChainOfResponsibilities/Tests/ChainTest.php
+++ b/Behavioral/ChainOfResponsibilities/Tests/ChainTest.php
@@ -23,7 +23,7 @@ class ChainTest extends TestCase
         );
     }
 
-    public function testCanRequestKeyInFastStorage()
+    public function testCanRequestKeyInFastStorage(): void
     {
         $uri = $this->createMock(UriInterface::class);
         $uri->method('getPath')->willReturn('/foo/bar');
@@ -37,7 +37,7 @@ class ChainTest extends TestCase
         $this->assertSame('Hello In Memory!', $this->chain->handle($request));
     }
 
-    public function testCanRequestKeyInSlowStorage()
+    public function testCanRequestKeyInSlowStorage(): void
     {
         $uri = $this->createMock(UriInterface::class);
         $uri->method('getPath')->willReturn('/foo/baz');

--- a/Behavioral/Command/AddMessageDateCommand.php
+++ b/Behavioral/Command/AddMessageDateCommand.php
@@ -21,7 +21,7 @@ class AddMessageDateCommand implements UndoableCommand
     /**
      * Execute and make receiver to enable displaying messages date.
      */
-    public function execute()
+    public function execute(): void
     {
         // sometimes, there is no receiver and this is the command which
         // does all the work
@@ -31,7 +31,7 @@ class AddMessageDateCommand implements UndoableCommand
     /**
      * Undo the command and make receiver to disable displaying messages date.
      */
-    public function undo()
+    public function undo(): void
     {
         // sometimes, there is no receiver and this is the command which
         // does all the work

--- a/Behavioral/Command/HelloCommand.php
+++ b/Behavioral/Command/HelloCommand.php
@@ -21,7 +21,7 @@ class HelloCommand implements Command
     /**
      * execute and output "Hello World".
      */
-    public function execute()
+    public function execute(): void
     {
         // sometimes, there is no receiver and this is the command which does all the work
         $this->output->write('Hello World');

--- a/Behavioral/Command/Invoker.php
+++ b/Behavioral/Command/Invoker.php
@@ -16,7 +16,7 @@ class Invoker
      * in the invoker we find this kind of method for subscribing the command
      * There can be also a stack, a list, a fixed set ...
      */
-    public function setCommand(Command $cmd)
+    public function setCommand(Command $cmd): void
     {
         $this->command = $cmd;
     }
@@ -24,7 +24,7 @@ class Invoker
     /**
      * executes the command; the invoker is the same whatever is the command
      */
-    public function run()
+    public function run(): void
     {
         $this->command->execute();
     }

--- a/Behavioral/Command/Receiver.php
+++ b/Behavioral/Command/Receiver.php
@@ -16,7 +16,7 @@ class Receiver
      */
     private array $output = [];
 
-    public function write(string $str)
+    public function write(string $str): void
     {
         if ($this->enableDate) {
             $str .= ' [' . date('Y-m-d') . ']';
@@ -33,7 +33,7 @@ class Receiver
     /**
      * Enable receiver to display message date
      */
-    public function enableDate()
+    public function enableDate(): void
     {
         $this->enableDate = true;
     }
@@ -41,7 +41,7 @@ class Receiver
     /**
      * Disable receiver to display message date
      */
-    public function disableDate()
+    public function disableDate(): void
     {
         $this->enableDate = false;
     }

--- a/Behavioral/Command/Tests/CommandTest.php
+++ b/Behavioral/Command/Tests/CommandTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class CommandTest extends TestCase
 {
-    public function testInvocation()
+    public function testInvocation(): void
     {
         $invoker = new Invoker();
         $receiver = new Receiver();

--- a/Behavioral/Command/Tests/UndoableCommandTest.php
+++ b/Behavioral/Command/Tests/UndoableCommandTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class UndoableCommandTest extends TestCase
 {
-    public function testInvocation()
+    public function testInvocation(): void
     {
         $invoker = new Invoker();
         $receiver = new Receiver();

--- a/Behavioral/Interpreter/Context.php
+++ b/Behavioral/Interpreter/Context.php
@@ -19,7 +19,7 @@ class Context
         return $this->poolVariable[$name];
     }
 
-    public function assign(VariableExp $variable, bool $val)
+    public function assign(VariableExp $variable, bool $val): void
     {
         $this->poolVariable[$variable->getName()] = $val;
     }

--- a/Behavioral/Interpreter/Tests/InterpreterTest.php
+++ b/Behavioral/Interpreter/Tests/InterpreterTest.php
@@ -25,7 +25,7 @@ class InterpreterTest extends TestCase
         $this->c = new VariableExp('C');
     }
 
-    public function testOr()
+    public function testOr(): void
     {
         $this->context->assign($this->a, false);
         $this->context->assign($this->b, false);
@@ -44,7 +44,7 @@ class InterpreterTest extends TestCase
         $this->assertTrue($result2, '(A ∨ B) ∨ C must true');
     }
 
-    public function testAnd()
+    public function testAnd(): void
     {
         $this->context->assign($this->a, true);
         $this->context->assign($this->b, true);

--- a/Behavioral/Iterator/BookList.php
+++ b/Behavioral/Iterator/BookList.php
@@ -15,12 +15,12 @@ class BookList implements Countable, Iterator
     private array $books = [];
     private int $currentIndex = 0;
 
-    public function addBook(Book $book)
+    public function addBook(Book $book): void
     {
         $this->books[] = $book;
     }
 
-    public function removeBook(Book $bookToRemove)
+    public function removeBook(Book $bookToRemove): void
     {
         foreach ($this->books as $key => $book) {
             if ($book->getAuthorAndTitle() === $bookToRemove->getAuthorAndTitle()) {
@@ -46,12 +46,12 @@ class BookList implements Countable, Iterator
         return $this->currentIndex;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->currentIndex++;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->currentIndex = 0;
     }

--- a/Behavioral/Iterator/Tests/IteratorTest.php
+++ b/Behavioral/Iterator/Tests/IteratorTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class IteratorTest extends TestCase
 {
-    public function testCanIterateOverBookList()
+    public function testCanIterateOverBookList(): void
     {
         $bookList = new BookList();
         $bookList->addBook(new Book('Learning PHP Design Patterns', 'William Sanders'));
@@ -33,7 +33,7 @@ class IteratorTest extends TestCase
         );
     }
 
-    public function testCanIterateOverBookListAfterRemovingBook()
+    public function testCanIterateOverBookListAfterRemovingBook(): void
     {
         $book = new Book('Clean Code', 'Robert C. Martin');
         $book2 = new Book('Professional Php Design Patterns', 'Aaron Saray');
@@ -54,7 +54,7 @@ class IteratorTest extends TestCase
         );
     }
 
-    public function testCanAddBookToList()
+    public function testCanAddBookToList(): void
     {
         $book = new Book('Clean Code', 'Robert C. Martin');
 
@@ -64,7 +64,7 @@ class IteratorTest extends TestCase
         $this->assertCount(1, $bookList);
     }
 
-    public function testCanRemoveBookFromList()
+    public function testCanRemoveBookFromList(): void
     {
         $book = new Book('Clean Code', 'Robert C. Martin');
 

--- a/Behavioral/Mediator/Colleague.php
+++ b/Behavioral/Mediator/Colleague.php
@@ -8,7 +8,7 @@ abstract class Colleague
 {
     protected Mediator $mediator;
 
-    public function setMediator(Mediator $mediator)
+    public function setMediator(Mediator $mediator): void
     {
         $this->mediator = $mediator;
     }

--- a/Behavioral/Mediator/Tests/MediatorTest.php
+++ b/Behavioral/Mediator/Tests/MediatorTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class MediatorTest extends TestCase
 {
-    public function testOutputHelloWorld()
+    public function testOutputHelloWorld(): void
     {
         $mediator = new UserRepositoryUiMediator(new UserRepository(), new Ui());
 

--- a/Behavioral/Mediator/Ui.php
+++ b/Behavioral/Mediator/Ui.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\Mediator;
 
 class Ui extends Colleague
 {
-    public function outputUserInfo(string $username)
+    public function outputUserInfo(string $username): void
     {
         echo $this->mediator->getUser($username);
     }

--- a/Behavioral/Mediator/UserRepositoryUiMediator.php
+++ b/Behavioral/Mediator/UserRepositoryUiMediator.php
@@ -12,7 +12,7 @@ class UserRepositoryUiMediator implements Mediator
         $this->ui->setMediator($this);
     }
 
-    public function printInfoAbout(string $user)
+    public function printInfoAbout(string $user): void
     {
         $this->ui->outputUserInfo($user);
     }

--- a/Behavioral/Memento/State.php
+++ b/Behavioral/Memento/State.php
@@ -32,7 +32,7 @@ class State implements \Stringable
         $this->state = $state;
     }
 
-    private static function ensureIsValidState(string $state)
+    private static function ensureIsValidState(string $state): void
     {
         if (!in_array($state, self::$validStates)) {
             throw new InvalidArgumentException('Invalid state given');

--- a/Behavioral/Memento/Tests/MementoTest.php
+++ b/Behavioral/Memento/Tests/MementoTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class MementoTest extends TestCase
 {
-    public function testOpenTicketAssignAndSetBackToOpen()
+    public function testOpenTicketAssignAndSetBackToOpen(): void
     {
         $ticket = new Ticket();
 

--- a/Behavioral/Memento/Ticket.php
+++ b/Behavioral/Memento/Ticket.php
@@ -16,17 +16,17 @@ class Ticket
         $this->currentState = new State(State::STATE_CREATED);
     }
 
-    public function open()
+    public function open(): void
     {
         $this->currentState = new State(State::STATE_OPENED);
     }
 
-    public function assign()
+    public function assign(): void
     {
         $this->currentState = new State(State::STATE_ASSIGNED);
     }
 
-    public function close()
+    public function close(): void
     {
         $this->currentState = new State(State::STATE_CLOSED);
     }
@@ -36,7 +36,7 @@ class Ticket
         return new Memento(clone $this->currentState);
     }
 
-    public function restoreFromMemento(Memento $memento)
+    public function restoreFromMemento(Memento $memento): void
     {
         $this->currentState = $memento->getState();
     }

--- a/Behavioral/NullObject/NullLogger.php
+++ b/Behavioral/NullObject/NullLogger.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\NullObject;
 
 class NullLogger implements Logger
 {
-    public function log(string $str)
+    public function log(string $str): void
     {
         // do nothing
     }

--- a/Behavioral/NullObject/PrintLogger.php
+++ b/Behavioral/NullObject/PrintLogger.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\NullObject;
 
 class PrintLogger implements Logger
 {
-    public function log(string $str)
+    public function log(string $str): void
     {
         echo $str;
     }

--- a/Behavioral/NullObject/Service.php
+++ b/Behavioral/NullObject/Service.php
@@ -13,7 +13,7 @@ class Service
     /**
      * do something ...
      */
-    public function doSomething()
+    public function doSomething(): void
     {
         // notice here that you don't have to check if the logger is set with eg. is_null(), instead just use it
         $this->logger->log('We are in ' . __METHOD__);

--- a/Behavioral/NullObject/Tests/LoggerTest.php
+++ b/Behavioral/NullObject/Tests/LoggerTest.php
@@ -11,14 +11,14 @@ use PHPUnit\Framework\TestCase;
 
 class LoggerTest extends TestCase
 {
-    public function testNullObject()
+    public function testNullObject(): void
     {
         $service = new Service(new NullLogger());
         $this->expectOutputString('');
         $service->doSomething();
     }
 
-    public function testStandardLogger()
+    public function testStandardLogger(): void
     {
         $service = new Service(new PrintLogger());
         $this->expectOutputString('We are in DesignPatterns\Behavioral\NullObject\Service::doSomething');

--- a/Behavioral/Observer/Tests/ObserverTest.php
+++ b/Behavioral/Observer/Tests/ObserverTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class ObserverTest extends TestCase
 {
-    public function testChangeInUserLeadsToUserObserverBeingNotified()
+    public function testChangeInUserLeadsToUserObserverBeingNotified(): void
     {
         $observer = new UserObserver();
 

--- a/Behavioral/Specification/Tests/SpecificationTest.php
+++ b/Behavioral/Specification/Tests/SpecificationTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class SpecificationTest extends TestCase
 {
-    public function testCanOr()
+    public function testCanOr(): void
     {
         $spec1 = new PriceSpecification(50, 99);
         $spec2 = new PriceSpecification(101, 200);
@@ -25,7 +25,7 @@ class SpecificationTest extends TestCase
         $this->assertTrue($orSpec->isSatisfiedBy(new Item(150)));
     }
 
-    public function testCanAnd()
+    public function testCanAnd(): void
     {
         $spec1 = new PriceSpecification(50, 100);
         $spec2 = new PriceSpecification(80, 200);
@@ -38,7 +38,7 @@ class SpecificationTest extends TestCase
         $this->assertTrue($andSpec->isSatisfiedBy(new Item(100)));
     }
 
-    public function testCanNot()
+    public function testCanNot(): void
     {
         $spec1 = new PriceSpecification(50, 100);
         $notSpec = new NotSpecification($spec1);

--- a/Behavioral/State/OrderContext.php
+++ b/Behavioral/State/OrderContext.php
@@ -16,12 +16,12 @@ class OrderContext
         return $order;
     }
 
-    public function setState(State $state)
+    public function setState(State $state): void
     {
         $this->state = $state;
     }
 
-    public function proceedToNext()
+    public function proceedToNext(): void
     {
         $this->state->proceedToNext($this);
     }

--- a/Behavioral/State/StateCreated.php
+++ b/Behavioral/State/StateCreated.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\State;
 
 class StateCreated implements State
 {
-    public function proceedToNext(OrderContext $context)
+    public function proceedToNext(OrderContext $context): void
     {
         $context->setState(new StateShipped());
     }

--- a/Behavioral/State/StateDone.php
+++ b/Behavioral/State/StateDone.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\State;
 
 class StateDone implements State
 {
-    public function proceedToNext(OrderContext $context)
+    public function proceedToNext(OrderContext $context): void
     {
         // there is nothing more to do
     }

--- a/Behavioral/State/StateShipped.php
+++ b/Behavioral/State/StateShipped.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Behavioral\State;
 
 class StateShipped implements State
 {
-    public function proceedToNext(OrderContext $context)
+    public function proceedToNext(OrderContext $context): void
     {
         $context->setState(new StateDone());
     }

--- a/Behavioral/State/Tests/StateTest.php
+++ b/Behavioral/State/Tests/StateTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 class StateTest extends TestCase
 {
-    public function testIsCreatedWithStateCreated()
+    public function testIsCreatedWithStateCreated(): void
     {
         $orderContext = OrderContext::create();
 
         $this->assertSame('created', $orderContext->toString());
     }
 
-    public function testCanProceedToStateShipped()
+    public function testCanProceedToStateShipped(): void
     {
         $contextOrder = OrderContext::create();
         $contextOrder->proceedToNext();
@@ -24,7 +24,7 @@ class StateTest extends TestCase
         $this->assertSame('shipped', $contextOrder->toString());
     }
 
-    public function testCanProceedToStateDone()
+    public function testCanProceedToStateDone(): void
     {
         $contextOrder = OrderContext::create();
         $contextOrder->proceedToNext();
@@ -33,7 +33,7 @@ class StateTest extends TestCase
         $this->assertSame('done', $contextOrder->toString());
     }
 
-    public function testStateDoneIsTheLastPossibleState()
+    public function testStateDoneIsTheLastPossibleState(): void
     {
         $contextOrder = OrderContext::create();
         $contextOrder->proceedToNext();

--- a/Behavioral/Strategy/Tests/StrategyTest.php
+++ b/Behavioral/Strategy/Tests/StrategyTest.php
@@ -45,7 +45,7 @@ class StrategyTest extends TestCase
      * @param array $collection
      * @param array $expected
      */
-    public function testIdComparator($collection, $expected)
+    public function testIdComparator($collection, $expected): void
     {
         $obj = new Context(new IdComparator());
         $elements = $obj->executeStrategy($collection);
@@ -60,7 +60,7 @@ class StrategyTest extends TestCase
      * @param array $collection
      * @param array $expected
      */
-    public function testDateComparator($collection, $expected)
+    public function testDateComparator($collection, $expected): void
     {
         $obj = new Context(new DateComparator());
         $elements = $obj->executeStrategy($collection);

--- a/Behavioral/TemplateMethod/Journey.php
+++ b/Behavioral/TemplateMethod/Journey.php
@@ -17,7 +17,7 @@ abstract class Journey
      * If you want to override this contract, make an interface with only takeATrip()
      * and subclass it.
      */
-    final public function takeATrip()
+    final public function takeATrip(): void
     {
         $this->thingsToDo[] = $this->buyAFlight();
         $this->thingsToDo[] = $this->takePlane();

--- a/Behavioral/TemplateMethod/Tests/JourneyTest.php
+++ b/Behavioral/TemplateMethod/Tests/JourneyTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class JourneyTest extends TestCase
 {
-    public function testCanGetOnVacationOnTheBeach()
+    public function testCanGetOnVacationOnTheBeach(): void
     {
         $beachJourney = new BeachJourney();
         $beachJourney->takeATrip();
@@ -21,7 +21,7 @@ class JourneyTest extends TestCase
         );
     }
 
-    public function testCanGetOnAJourneyToACity()
+    public function testCanGetOnAJourneyToACity(): void
     {
         $cityJourney = new CityJourney();
         $cityJourney->takeATrip();

--- a/Behavioral/Visitor/Group.php
+++ b/Behavioral/Visitor/Group.php
@@ -15,7 +15,7 @@ class Group implements Role
         return sprintf('Group: %s', $this->name);
     }
 
-    public function accept(RoleVisitor $visitor)
+    public function accept(RoleVisitor $visitor): void
     {
         $visitor->visitGroup($this);
     }

--- a/Behavioral/Visitor/RecordingVisitor.php
+++ b/Behavioral/Visitor/RecordingVisitor.php
@@ -11,12 +11,12 @@ class RecordingVisitor implements RoleVisitor
      */
     private array $visited = [];
 
-    public function visitGroup(Group $role)
+    public function visitGroup(Group $role): void
     {
         $this->visited[] = $role;
     }
 
-    public function visitUser(User $role)
+    public function visitUser(User $role): void
     {
         $this->visited[] = $role;
     }

--- a/Behavioral/Visitor/Tests/VisitorTest.php
+++ b/Behavioral/Visitor/Tests/VisitorTest.php
@@ -31,7 +31,7 @@ class VisitorTest extends TestCase
     /**
      * @dataProvider provideRoles
      */
-    public function testVisitSomeRole(Role $role)
+    public function testVisitSomeRole(Role $role): void
     {
         $role->accept($this->visitor);
         $this->assertSame($role, $this->visitor->getVisited()[0]);

--- a/Behavioral/Visitor/User.php
+++ b/Behavioral/Visitor/User.php
@@ -15,7 +15,7 @@ class User implements Role
         return sprintf('User %s', $this->name);
     }
 
-    public function accept(RoleVisitor $visitor)
+    public function accept(RoleVisitor $visitor): void
     {
         $visitor->visitUser($this);
     }

--- a/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
+++ b/Creational/AbstractFactory/Tests/AbstractFactoryTest.php
@@ -24,7 +24,7 @@ class AbstractFactoryTest extends TestCase
     /**
      * @dataProvider provideFactory
      */
-    public function testCanCreateCsvWriterOnUnix(WriterFactory $writerFactory)
+    public function testCanCreateCsvWriterOnUnix(WriterFactory $writerFactory): void
     {
         $this->assertInstanceOf(JsonWriter::class, $writerFactory->createJsonWriter());
         $this->assertInstanceOf(CsvWriter::class, $writerFactory->createCsvWriter());

--- a/Creational/Builder/CarBuilder.php
+++ b/Creational/Builder/CarBuilder.php
@@ -14,19 +14,19 @@ class CarBuilder implements Builder
 {
     private Car $car;
 
-    public function addDoors()
+    public function addDoors(): void
     {
         $this->car->setPart('rightDoor', new Door());
         $this->car->setPart('leftDoor', new Door());
         $this->car->setPart('trunkLid', new Door());
     }
 
-    public function addEngine()
+    public function addEngine(): void
     {
         $this->car->setPart('engine', new Engine());
     }
 
-    public function addWheel()
+    public function addWheel(): void
     {
         $this->car->setPart('wheelLF', new Wheel());
         $this->car->setPart('wheelRF', new Wheel());
@@ -34,7 +34,7 @@ class CarBuilder implements Builder
         $this->car->setPart('wheelRR', new Wheel());
     }
 
-    public function createVehicle()
+    public function createVehicle(): void
     {
         $this->car = new Car();
     }

--- a/Creational/Builder/Parts/Vehicle.php
+++ b/Creational/Builder/Parts/Vehicle.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Creational\Builder\Parts;
 
 abstract class Vehicle
 {
-    public function setPart(string $key, object $value)
+    public function setPart(string $key, object $value): void
     {
     }
 }

--- a/Creational/Builder/Tests/DirectorTest.php
+++ b/Creational/Builder/Tests/DirectorTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class DirectorTest extends TestCase
 {
-    public function testCanBuildTruck()
+    public function testCanBuildTruck(): void
     {
         $truckBuilder = new TruckBuilder();
         $newVehicle = (new Director())->build($truckBuilder);
@@ -21,7 +21,7 @@ class DirectorTest extends TestCase
         $this->assertInstanceOf(Truck::class, $newVehicle);
     }
 
-    public function testCanBuildCar()
+    public function testCanBuildCar(): void
     {
         $carBuilder = new CarBuilder();
         $newVehicle = (new Director())->build($carBuilder);

--- a/Creational/Builder/TruckBuilder.php
+++ b/Creational/Builder/TruckBuilder.php
@@ -14,18 +14,18 @@ class TruckBuilder implements Builder
 {
     private Truck $truck;
 
-    public function addDoors()
+    public function addDoors(): void
     {
         $this->truck->setPart('rightDoor', new Door());
         $this->truck->setPart('leftDoor', new Door());
     }
 
-    public function addEngine()
+    public function addEngine(): void
     {
         $this->truck->setPart('truckEngine', new Engine());
     }
 
-    public function addWheel()
+    public function addWheel(): void
     {
         $this->truck->setPart('wheel1', new Wheel());
         $this->truck->setPart('wheel2', new Wheel());
@@ -35,7 +35,7 @@ class TruckBuilder implements Builder
         $this->truck->setPart('wheel6', new Wheel());
     }
 
-    public function createVehicle()
+    public function createVehicle(): void
     {
         $this->truck = new Truck();
     }

--- a/Creational/FactoryMethod/FileLogger.php
+++ b/Creational/FactoryMethod/FileLogger.php
@@ -10,7 +10,7 @@ class FileLogger implements Logger
     {
     }
 
-    public function log(string $message)
+    public function log(string $message): void
     {
         file_put_contents($this->filePath, $message . PHP_EOL, FILE_APPEND);
     }

--- a/Creational/FactoryMethod/StdoutLogger.php
+++ b/Creational/FactoryMethod/StdoutLogger.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Creational\FactoryMethod;
 
 class StdoutLogger implements Logger
 {
-    public function log(string $message)
+    public function log(string $message): void
     {
         echo $message;
     }

--- a/Creational/FactoryMethod/Tests/FactoryMethodTest.php
+++ b/Creational/FactoryMethod/Tests/FactoryMethodTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class FactoryMethodTest extends TestCase
 {
-    public function testCanCreateStdoutLogging()
+    public function testCanCreateStdoutLogging(): void
     {
         $loggerFactory = new StdoutLoggerFactory();
         $logger = $loggerFactory->createLogger();
@@ -20,7 +20,7 @@ class FactoryMethodTest extends TestCase
         $this->assertInstanceOf(StdoutLogger::class, $logger);
     }
 
-    public function testCanCreateFileLogging()
+    public function testCanCreateFileLogging(): void
     {
         $loggerFactory = new FileLoggerFactory(sys_get_temp_dir());
         $logger = $loggerFactory->createLogger();

--- a/Creational/Pool/Tests/PoolTest.php
+++ b/Creational/Pool/Tests/PoolTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class PoolTest extends TestCase
 {
-    public function testCanGetNewInstancesWithGet()
+    public function testCanGetNewInstancesWithGet(): void
     {
         $pool = new WorkerPool();
         $worker1 = $pool->get();
@@ -19,7 +19,7 @@ class PoolTest extends TestCase
         $this->assertNotSame($worker1, $worker2);
     }
 
-    public function testCanGetSameInstanceTwiceWhenDisposingItFirst()
+    public function testCanGetSameInstanceTwiceWhenDisposingItFirst(): void
     {
         $pool = new WorkerPool();
         $worker1 = $pool->get();

--- a/Creational/Pool/WorkerPool.php
+++ b/Creational/Pool/WorkerPool.php
@@ -31,7 +31,7 @@ class WorkerPool implements Countable
         return $worker;
     }
 
-    public function dispose(StringReverseWorker $worker)
+    public function dispose(StringReverseWorker $worker): void
     {
         $key = spl_object_hash($worker);
 

--- a/Creational/Prototype/Tests/PrototypeTest.php
+++ b/Creational/Prototype/Tests/PrototypeTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class PrototypeTest extends TestCase
 {
-    public function testCanGetFooBook()
+    public function testCanGetFooBook(): void
     {
         $fooPrototype = new FooBookPrototype();
         $barPrototype = new BarBookPrototype();

--- a/Creational/SimpleFactory/Bicycle.php
+++ b/Creational/SimpleFactory/Bicycle.php
@@ -6,7 +6,7 @@ namespace DesignPatterns\Creational\SimpleFactory;
 
 class Bicycle
 {
-    public function driveTo(string $destination)
+    public function driveTo(string $destination): void
     {
     }
 }

--- a/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
+++ b/Creational/SimpleFactory/Tests/SimpleFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class SimpleFactoryTest extends TestCase
 {
-    public function testCanCreateBicycle()
+    public function testCanCreateBicycle(): void
     {
         $bicycle = (new SimpleFactory())->createBicycle();
         $this->assertInstanceOf(Bicycle::class, $bicycle);

--- a/Creational/Singleton/Singleton.php
+++ b/Creational/Singleton/Singleton.php
@@ -40,7 +40,7 @@ final class Singleton
     /**
      * prevent from being unserialized (which would create a second instance of it)
      */
-    public function __wakeup()
+    public function __wakeup(): void
     {
         throw new Exception("Cannot unserialize singleton");
     }

--- a/Creational/Singleton/Tests/SingletonTest.php
+++ b/Creational/Singleton/Tests/SingletonTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class SingletonTest extends TestCase
 {
-    public function testUniqueness()
+    public function testUniqueness(): void
     {
         $firstCall = Singleton::getInstance();
         $secondCall = Singleton::getInstance();

--- a/Creational/StaticFactory/Tests/StaticFactoryTest.php
+++ b/Creational/StaticFactory/Tests/StaticFactoryTest.php
@@ -12,17 +12,17 @@ use PHPUnit\Framework\TestCase;
 
 class StaticFactoryTest extends TestCase
 {
-    public function testCanCreateNumberFormatter()
+    public function testCanCreateNumberFormatter(): void
     {
         $this->assertInstanceOf(FormatNumber::class, StaticFactory::factory('number'));
     }
 
-    public function testCanCreateStringFormatter()
+    public function testCanCreateStringFormatter(): void
     {
         $this->assertInstanceOf(FormatString::class, StaticFactory::factory('string'));
     }
 
-    public function testException()
+    public function testException(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/More/Repository/Domain/PostId.php
+++ b/More/Repository/Domain/PostId.php
@@ -31,7 +31,7 @@ class PostId
         return $this->id;
     }
 
-    private static function ensureIsValid(int $id)
+    private static function ensureIsValid(int $id): void
     {
         if ($id <= 0) {
             throw new InvalidArgumentException('Invalid PostId given');

--- a/More/Repository/Domain/PostStatus.php
+++ b/More/Repository/Domain/PostStatus.php
@@ -60,7 +60,7 @@ class PostStatus
         return $this->name;
     }
 
-    private static function ensureIsValidId(int $status)
+    private static function ensureIsValidId(int $status): void
     {
         if (!in_array($status, array_keys(self::$validStates), true)) {
             throw new InvalidArgumentException('Invalid status id given');
@@ -68,7 +68,7 @@ class PostStatus
     }
 
 
-    private static function ensureIsValidName(string $status)
+    private static function ensureIsValidName(string $status): void
     {
         if (!in_array($status, self::$validStates, true)) {
             throw new InvalidArgumentException('Invalid status name given');

--- a/More/Repository/InMemoryPersistence.php
+++ b/More/Repository/InMemoryPersistence.php
@@ -18,7 +18,7 @@ class InMemoryPersistence implements Persistence
         return $this->lastId;
     }
 
-    public function persist(array $data)
+    public function persist(array $data): void
     {
         $this->data[$this->lastId] = $data;
     }
@@ -32,7 +32,7 @@ class InMemoryPersistence implements Persistence
         return $this->data[$id];
     }
 
-    public function delete(int $id)
+    public function delete(int $id): void
     {
         if (!isset($this->data[$id])) {
             throw new OutOfBoundsException(sprintf('No data found for ID %d', $id));

--- a/More/Repository/PostRepository.php
+++ b/More/Repository/PostRepository.php
@@ -39,7 +39,7 @@ class PostRepository
         return Post::fromState($arrayData);
     }
 
-    public function save(Post $post)
+    public function save(Post $post): void
     {
         $this->persistence->persist([
             'id' => $post->getId()->toInt(),

--- a/More/Repository/Tests/PostRepositoryTest.php
+++ b/More/Repository/Tests/PostRepositoryTest.php
@@ -21,12 +21,12 @@ class PostRepositoryTest extends TestCase
         $this->repository = new PostRepository(new InMemoryPersistence());
     }
 
-    public function testCanGenerateId()
+    public function testCanGenerateId(): void
     {
         $this->assertEquals(1, $this->repository->generateId()->toInt());
     }
 
-    public function testThrowsExceptionWhenTryingToFindPostWhichDoesNotExist()
+    public function testThrowsExceptionWhenTryingToFindPostWhichDoesNotExist(): void
     {
         $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Post with id 42 does not exist');
@@ -34,7 +34,7 @@ class PostRepositoryTest extends TestCase
         $this->repository->findById(PostId::fromInt(42));
     }
 
-    public function testCanPersistPostDraft()
+    public function testCanPersistPostDraft(): void
     {
         $postId = $this->repository->generateId();
         $post = Post::draft($postId, 'Repository Pattern', 'Design Patterns PHP');

--- a/More/ServiceLocator/ServiceLocator.php
+++ b/More/ServiceLocator/ServiceLocator.php
@@ -19,12 +19,12 @@ class ServiceLocator
      */
     private array $instantiated = [];
 
-    public function addInstance(string $class, Service $service)
+    public function addInstance(string $class, Service $service): void
     {
         $this->instantiated[$class] = $service;
     }
 
-    public function addClass(string $class, array $params)
+    public function addClass(string $class, array $params): void
     {
         $this->services[$class] = $params;
     }

--- a/More/ServiceLocator/Tests/ServiceLocatorTest.php
+++ b/More/ServiceLocator/Tests/ServiceLocatorTest.php
@@ -17,7 +17,7 @@ class ServiceLocatorTest extends TestCase
         $this->serviceLocator = new ServiceLocator();
     }
 
-    public function testHasServices()
+    public function testHasServices(): void
     {
         $this->serviceLocator->addInstance(LogService::class, new LogService());
 
@@ -25,7 +25,7 @@ class ServiceLocatorTest extends TestCase
         $this->assertFalse($this->serviceLocator->has(self::class));
     }
 
-    public function testGetWillInstantiateLogServiceIfNoInstanceHasBeenCreatedYet()
+    public function testGetWillInstantiateLogServiceIfNoInstanceHasBeenCreatedYet(): void
     {
         $this->serviceLocator->addClass(LogService::class, []);
         $logger = $this->serviceLocator->get(LogService::class);

--- a/Structural/Adapter/EBookAdapter.php
+++ b/Structural/Adapter/EBookAdapter.php
@@ -17,12 +17,12 @@ class EBookAdapter implements Book
     /**
      * This class makes the proper translation from one interface to another.
      */
-    public function open()
+    public function open(): void
     {
         $this->eBook->unlock();
     }
 
-    public function turnPage()
+    public function turnPage(): void
     {
         $this->eBook->pressNext();
     }

--- a/Structural/Adapter/Kindle.php
+++ b/Structural/Adapter/Kindle.php
@@ -13,12 +13,12 @@ class Kindle implements EBook
     private int $page = 1;
     private int $totalPages = 100;
 
-    public function pressNext()
+    public function pressNext(): void
     {
         $this->page++;
     }
 
-    public function unlock()
+    public function unlock(): void
     {
     }
 

--- a/Structural/Adapter/Tests/AdapterTest.php
+++ b/Structural/Adapter/Tests/AdapterTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class AdapterTest extends TestCase
 {
-    public function testCanTurnPageOnBook()
+    public function testCanTurnPageOnBook(): void
     {
         $book = new PaperBook();
         $book->open();
@@ -20,7 +20,7 @@ class AdapterTest extends TestCase
         $this->assertSame(2, $book->getPage());
     }
 
-    public function testCanTurnPageOnKindleLikeInANormalBook()
+    public function testCanTurnPageOnKindleLikeInANormalBook(): void
     {
         $kindle = new Kindle();
         $book = new EBookAdapter($kindle);

--- a/Structural/Bridge/Service.php
+++ b/Structural/Bridge/Service.php
@@ -10,7 +10,7 @@ abstract class Service
     {
     }
 
-    public function setImplementation(Formatter $printer)
+    public function setImplementation(Formatter $printer): void
     {
         $this->implementation = $printer;
     }

--- a/Structural/Bridge/Tests/BridgeTest.php
+++ b/Structural/Bridge/Tests/BridgeTest.php
@@ -11,14 +11,14 @@ use PHPUnit\Framework\TestCase;
 
 class BridgeTest extends TestCase
 {
-    public function testCanPrintUsingThePlainTextFormatter()
+    public function testCanPrintUsingThePlainTextFormatter(): void
     {
         $service = new HelloWorldService(new PlainTextFormatter());
 
         $this->assertSame('Hello World', $service->get());
     }
 
-    public function testCanPrintUsingTheHtmlFormatter()
+    public function testCanPrintUsingTheHtmlFormatter(): void
     {
         $service = new HelloWorldService(new HtmlFormatter());
 

--- a/Structural/Composite/Form.php
+++ b/Structural/Composite/Form.php
@@ -32,7 +32,7 @@ class Form implements Renderable
         return $formCode . '</form>';
     }
 
-    public function addElement(Renderable $element)
+    public function addElement(Renderable $element): void
     {
         $this->elements[] = $element;
     }

--- a/Structural/Composite/Tests/CompositeTest.php
+++ b/Structural/Composite/Tests/CompositeTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class CompositeTest extends TestCase
 {
-    public function testRender()
+    public function testRender(): void
     {
         $form = new Form();
         $form->addElement(new TextElement('Email:'));

--- a/Structural/DataMapper/Tests/DataMapperTest.php
+++ b/Structural/DataMapper/Tests/DataMapperTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class DataMapperTest extends TestCase
 {
-    public function testCanMapUserFromStorage()
+    public function testCanMapUserFromStorage(): void
     {
         $storage = new StorageAdapter([1 => ['username' => 'domnikl', 'email' => 'liebler.dominik@gmail.com']]);
         $mapper = new UserMapper($storage);
@@ -22,7 +22,7 @@ class DataMapperTest extends TestCase
         $this->assertInstanceOf(User::class, $user);
     }
 
-    public function testWillNotMapInvalidData()
+    public function testWillNotMapInvalidData(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/Structural/Decorator/Tests/DecoratorTest.php
+++ b/Structural/Decorator/Tests/DecoratorTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class DecoratorTest extends TestCase
 {
-    public function testCanCalculatePriceForBasicDoubleRoomBooking()
+    public function testCanCalculatePriceForBasicDoubleRoomBooking(): void
     {
         $booking = new DoubleRoomBooking();
 
@@ -19,7 +19,7 @@ class DecoratorTest extends TestCase
         $this->assertSame('double room', $booking->getDescription());
     }
 
-    public function testCanCalculatePriceForDoubleRoomBookingWithWiFi()
+    public function testCanCalculatePriceForDoubleRoomBookingWithWiFi(): void
     {
         $booking = new DoubleRoomBooking();
         $booking = new WiFi($booking);
@@ -28,7 +28,7 @@ class DecoratorTest extends TestCase
         $this->assertSame('double room with wifi', $booking->getDescription());
     }
 
-    public function testCanCalculatePriceForDoubleRoomBookingWithWiFiAndExtraBed()
+    public function testCanCalculatePriceForDoubleRoomBookingWithWiFiAndExtraBed(): void
     {
         $booking = new DoubleRoomBooking();
         $booking = new WiFi($booking);

--- a/Structural/DependencyInjection/Tests/DependencyInjectionTest.php
+++ b/Structural/DependencyInjection/Tests/DependencyInjectionTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class DependencyInjectionTest extends TestCase
 {
-    public function testDependencyInjection()
+    public function testDependencyInjection(): void
     {
         $config = new DatabaseConfiguration('localhost', 3306, 'domnikl', '1234');
         $connection = new DatabaseConnection($config);

--- a/Structural/Facade/Facade.php
+++ b/Structural/Facade/Facade.php
@@ -10,14 +10,14 @@ class Facade
     {
     }
 
-    public function turnOn()
+    public function turnOn(): void
     {
         $this->bios->execute();
         $this->bios->waitForKeyPress();
         $this->bios->launch($this->os);
     }
 
-    public function turnOff()
+    public function turnOff(): void
     {
         $this->os->halt();
         $this->bios->powerDown();

--- a/Structural/Facade/Tests/FacadeTest.php
+++ b/Structural/Facade/Tests/FacadeTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class FacadeTest extends TestCase
 {
-    public function testComputerOn()
+    public function testComputerOn(): void
     {
         $os = $this->createMock(OperatingSystem::class);
 

--- a/Structural/FluentInterface/Tests/FluentInterfaceTest.php
+++ b/Structural/FluentInterface/Tests/FluentInterfaceTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class FluentInterfaceTest extends TestCase
 {
-    public function testBuildSQL()
+    public function testBuildSQL(): void
     {
         $query = (new Sql())
                 ->select(['foo', 'bar'])

--- a/Structural/Flyweight/Tests/FlyweightTest.php
+++ b/Structural/Flyweight/Tests/FlyweightTest.php
@@ -14,7 +14,7 @@ class FlyweightTest extends TestCase
 
     private array $fonts = ['Arial', 'Times New Roman', 'Verdana', 'Helvetica'];
 
-    public function testFlyweight()
+    public function testFlyweight(): void
     {
         $factory = new TextFactory();
 

--- a/Structural/Proxy/HeavyBankAccount.php
+++ b/Structural/Proxy/HeavyBankAccount.php
@@ -11,7 +11,7 @@ class HeavyBankAccount implements BankAccount
      */
     private array $transactions = [];
 
-    public function deposit(int $amount)
+    public function deposit(int $amount): void
     {
         $this->transactions[] = $amount;
     }

--- a/Structural/Proxy/Tests/ProxyTest.php
+++ b/Structural/Proxy/Tests/ProxyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ProxyTest extends TestCase
 {
-    public function testProxyWillOnlyExecuteExpensiveGetBalanceOnce()
+    public function testProxyWillOnlyExecuteExpensiveGetBalanceOnce(): void
     {
         $bankAccount = new BankAccountProxy();
         $bankAccount->deposit(30);

--- a/Structural/Registry/Registry.php
+++ b/Structural/Registry/Registry.php
@@ -22,7 +22,7 @@ abstract class Registry
         self::LOGGER,
     ];
 
-    public static function set(string $key, Service $value)
+    public static function set(string $key, Service $value): void
     {
         if (!in_array($key, self::$allowedKeys)) {
             throw new InvalidArgumentException('Invalid key given');

--- a/Structural/Registry/Tests/RegistryTest.php
+++ b/Structural/Registry/Tests/RegistryTest.php
@@ -18,14 +18,14 @@ class RegistryTest extends TestCase
         $this->service = $this->getMockBuilder(Service::class)->getMock();
     }
 
-    public function testSetAndGetLogger()
+    public function testSetAndGetLogger(): void
     {
         Registry::set(Registry::LOGGER, $this->service);
 
         $this->assertSame($this->service, Registry::get(Registry::LOGGER));
     }
 
-    public function testThrowsExceptionWhenTryingToSetInvalidKey()
+    public function testThrowsExceptionWhenTryingToSetInvalidKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -39,7 +39,7 @@ class RegistryTest extends TestCase
      *
      * @runInSeparateProcess
      */
-    public function testThrowsExceptionWhenTryingToGetNotSetKey()
+    public function testThrowsExceptionWhenTryingToGetNotSetKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.