### PR TITLE
[f] compatible with Iterator

### DIFF
--- a/Behavioral/Iterator/BookList.php
+++ b/Behavioral/Iterator/BookList.php
@@ -46,12 +46,12 @@ class BookList implements Countable, Iterator
         return $this->currentIndex;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->currentIndex++;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->currentIndex = 0;
     }


### PR DESCRIPTION
PHP Deprecated: Return type of DesignPatterns\Behavioral\Iterator\BookList::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange]
PHP Deprecated: Return type of DesignPatterns\Behavioral\Iterator\BookList::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange]